### PR TITLE
kernel-rebase: Tidy up slightly

### DIFF
--- a/kernel-rebase.sh
+++ b/kernel-rebase.sh
@@ -1,5 +1,11 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
+# Colours
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NORMAL='\033[0m'
+
+# Project Directory
 PROJECT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 # Variables
@@ -8,28 +14,21 @@ OEM_KERNEL=${1}
 ACK_BRANCH=${2}
 
 # Help Function
-function usage() {
-    echo -e "${0} \"link to oem kernel source (git)\" \"ack-branch\"
-    >> eg: ${0} \"https://github.com/MiCode/Xiaomi_Kernel_OpenSource.git -b dandelion-q-oss\" \"android-4.9-q\""
+usage() {
+	echo -e "${0} \"link to oem kernel source (git)\" \"ack-branch\"
+	>> eg: ${0} \"https://github.com/MiCode/Xiaomi_Kernel_OpenSource.git -b dandelion-q-oss\" \"android-4.9-q\""
 }
 
-# Colours
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-ORANGE='\033[0;33m'
-BLUE='\033[0;34m'
-NORMAL='\033[0m'
-
 # Abort Function
-function abort() {
-    [ ! -z "${@}" ] && echo -e ${RED}"${@}"${NORMAL}
-    exit 1
+abort() {
+	[ ! -z "${@}" ] && echo -e ${RED}"${@}"${NORMAL}
+	exit 1
 }
 
 # Clone the OEM Kernel Source
 git clone --depth=1 --single-branch $(echo ${OEM_KERNEL}) oem
 
-# Clone the Android Common Kernel
+# Clone the Android Common Kernel Source
 git clone --single-branch -b ${ACK_BRANCH} ${ACK_REPO} kernel
 
 # Get the OEM Kernel's Version
@@ -51,7 +50,7 @@ cd -
 # Start Rebasing
 cd kernel
 for i in ${OEM_DIR_LIST}; do
-    rm -rf ${i}
+	rm -rf ${i}
 done
 
 cd -
@@ -59,9 +58,10 @@ cp -r oem/* kernel/
 cd kernel
 
 for i in ${OEM_DIR_LIST}; do
-    git add ${i}
-    git commit -s -m "${i}: Import OEM Changes"
+	git add ${i}
+	git commit -s -m "${i}: Import OEM Changes"
 done
+
 git add .
 git commit -s -m "Import Remaining OEM Changes"
 


### PR DESCRIPTION
- Address bash with env for shebang.
- Use tab indentations.
- Do not explicitly mention "function".
- Move color variables to the top for cosmetic change.
- Remove unused color variables.
- Rework on some comments.

Signed-off-by: Tashfin Shakeer Rhythm <tashfinshakeerrhythm@gmail.com>